### PR TITLE
Spartacus: speed up initial load

### DIFF
--- a/xdn-spartacus-example/routes.ts
+++ b/xdn-spartacus-example/routes.ts
@@ -62,6 +62,8 @@ export default new Router()
     proxy('commerce')
   })
   // Main app pages:
+  .get('/', ({ redirect }) => redirect('/electronics-spa/'))
+  .get('/electronics-spa', ssrPageCacheHandler)
   .get('/electronics-spa/open-Catalogue/:path*', ssrPageCacheHandler)
   .get('/electronics-spa/product/:path*', ssrPageCacheHandler)
   .get('/electronics-spa/Brands/:path*', ssrPageCacheHandler)


### PR DESCRIPTION
This makes https://moovweb-docs-xdn-spartacus-example-default.moovweb-edge.io/ demo initial load to be very fast